### PR TITLE
Use doggos dataset in shared storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Navigate to [console.anyscale.com](https://console.anyscale.com) and sign in wit
 
 ### Demo Execution
 
-- Navigate to the VSCode (not VSCode Desktop)
+- Navigate to the VSCode interface (not VSCode Desktop)
 - Access notebooks/01-Batch-Inference.ipynb
 - **[Optional]** Modify the Batch Inference notebook to use a shared storage mount
 In the start of the section "Data ingestion" replace the code with a reference to S3 to:


### PR DESCRIPTION
## Summary
- Updated the Batch Inference notebook to use the doggos dataset from shared storage mount instead of Azure Blob Storage
- Simplified data loading by using the `/mnt/shared_storage/doggos-dataset/train` path
- Removed Azure-specific filesystem configuration code

## Test plan
- [ ] Run the Batch Inference notebook (notebooks/01-Batch-Inference.ipynb)
- [ ] Verify data loads successfully from shared storage mount
- [ ] Confirm batch inference operations complete without errors